### PR TITLE
If duration = 0 then -n

### DIFF
--- a/grub2beep.py
+++ b/grub2beep.py
@@ -22,6 +22,9 @@ for note in range(0, len(notes), 2):
     if frequency == 0:
         output.append(f"-D {duration}")
         continue
+    if duration == 0:
+        output.append(f"-n")
+        continue
     output.append(f"-n -f {frequency} -l {duration}")
 
 output = " ".join(output).strip()


### PR DESCRIPTION
I mean for some reason sometimes duration is = 0.  Since that isn't even a note adds a -n also
Duration = 0 crash some beep.c implementations. so this may fix them